### PR TITLE
Use ubuntu-debootstrap in order to reduce the image size. Before 298.5 MB after 217.4 MB

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu
+FROM ubuntu-debootstrap:14.04
 MAINTAINER Christian Lück <christian@lueck.tv>
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y \


### PR DESCRIPTION
Hi Christian
First of all thank for sharing your docker images. It's work perfectly !
I did a small optimisation on the image size and I share it.

Tell me what you think
Have a good day
