### PR TITLE
Increase the upload file size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,9 +18,12 @@ RUN wget https://raw.github.com/vrana/adminer/master/designs/hever/adminer.css -
 WORKDIR /var/www
 RUN chown www-data:www-data -R /var/www
 
+# Increase PHP upload limit
+RUN echo "upload_max_filesize = 100M" >> /etc/php5/cli/conf.d/upload_max_filesize.ini
+RUN echo "post_max_size = 100M" >> /etc/php5/cli/conf.d/post_max_size.ini
+
 # expose only nginx HTTP port
 EXPOSE 80
 
 ADD supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 CMD supervisord -c /etc/supervisor/conf.d/supervisord.conf
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,8 @@ WORKDIR /var/www
 RUN chown www-data:www-data -R /var/www
 
 # Increase PHP upload limit
-RUN echo "upload_max_filesize = 100M" >> /etc/php5/cli/conf.d/upload_max_filesize.ini
-RUN echo "post_max_size = 100M" >> /etc/php5/cli/conf.d/post_max_size.ini
+RUN echo "upload_max_filesize = 2000M" >> /etc/php5/cli/conf.d/upload_max_filesize.ini
+RUN echo "post_max_size = 2000M" >> /etc/php5/cli/conf.d/post_max_size.ini
 
 # expose only nginx HTTP port
 EXPOSE 80

--- a/adminer.nginx.conf
+++ b/adminer.nginx.conf
@@ -2,8 +2,8 @@ server {
 	listen 80;
 	root /var/www;
 
-	# Increase the upload size to 100M.
-	client_max_body_size 100M;
+	# Increase the upload size to 2000M.
+	client_max_body_size 2000M;
 
 	index index.php index.html;
 

--- a/adminer.nginx.conf
+++ b/adminer.nginx.conf
@@ -2,6 +2,9 @@ server {
 	listen 80;
 	root /var/www;
 
+	# Increase the upload size to 100M.
+	client_max_body_size 100M;
+
 	index index.php index.html;
 
 	location / {
@@ -15,4 +18,3 @@ server {
 		include fastcgi_params;
 	}
 }
-


### PR DESCRIPTION
This will allow you to upload .tar.gz database dumps that are greater than 2M.