### PR TITLE
Install php5-mongo extension.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ MAINTAINER Christian Lück <christian@lueck.tv>
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y \
   nginx supervisor php5-fpm php5-cli \
-  php5-pgsql php5-mysql php5-sqlite php5-mssql \
+  php5-pgsql php5-mysql php5-sqlite php5-mssql php5-mongo \
   wget
 
 # add adminer as the only nginx site


### PR DESCRIPTION
To avoid this error `None of the supported PHP extensions (mongo) are available` we need to install `php5-mongo`.

So, I add it in the Dockerfile.